### PR TITLE
Testing out a different HashSet implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,4 +18,11 @@
         <maven.compiler.source>11</maven.compiler.source>
         <envSources>src/main/java11</envSources>
     </properties>
+    <dependencies>
+        <dependency>
+            <groupId>it.unimi.dsi</groupId>
+            <artifactId>fastutil</artifactId>
+            <version>8.5.12</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/src/main/java/no/hasmac/jsonld/context/InverseContext.java
+++ b/src/main/java/no/hasmac/jsonld/context/InverseContext.java
@@ -15,7 +15,11 @@
  */
 package no.hasmac.jsonld.context;
 
-import java.util.LinkedHashMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+
 import java.util.Map;
 import java.util.Optional;
 
@@ -24,13 +28,13 @@ public final class InverseContext {
     private final Map<String, Map<String, Map<String, Map<String, String>>>> context;
 
     public InverseContext() {
-        this.context = new LinkedHashMap<>();
+        this.context = new Object2ObjectOpenHashMap<>();
     }
 
     private void set(final String variable, final String container, final String type, final String key, final String value) {
-        context.computeIfAbsent(variable, x -> new LinkedHashMap<>())
-                .computeIfAbsent(container, x -> new LinkedHashMap<>())
-                .computeIfAbsent(type, x -> new LinkedHashMap<>())
+        context.computeIfAbsent(variable, x -> new Object2ObjectOpenHashMap<>())
+                .computeIfAbsent(container, x -> new Object2ObjectOpenHashMap<>())
+                .computeIfAbsent(type, x -> new Object2ObjectLinkedOpenHashMap<>())
                 .put(key, value);
     }
 

--- a/src/main/java/no/hasmac/jsonld/flattening/NodeMap.java
+++ b/src/main/java/no/hasmac/jsonld/flattening/NodeMap.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
+import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
 import no.hasmac.jsonld.json.JsonProvider;
 import no.hasmac.jsonld.json.JsonUtils;
@@ -37,7 +38,7 @@ public final class NodeMap {
     private final BlankNodeIdGenerator generator = new BlankNodeIdGenerator();
 
     public NodeMap() {
-        this.index = new Object2ObjectLinkedOpenHashMap<>(2);
+        this.index = new Object2ObjectArrayMap<>(2);
         this.index.put(Keywords.DEFAULT, new Object2ObjectLinkedOpenHashMap<>(1));
     }
 
@@ -49,7 +50,7 @@ public final class NodeMap {
 
         index
                 .computeIfAbsent(graphName, x -> new Object2ObjectLinkedOpenHashMap<>())
-                .computeIfAbsent(subject, x -> new Object2ObjectLinkedOpenHashMap<>(1))
+                .computeIfAbsent(subject, x -> new Object2ObjectArrayMap<>(1))
                 .put(property, value);
     }
 

--- a/src/main/java/no/hasmac/jsonld/flattening/NodeMap.java
+++ b/src/main/java/no/hasmac/jsonld/flattening/NodeMap.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
+import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
 import no.hasmac.jsonld.json.JsonProvider;
 import no.hasmac.jsonld.json.JsonUtils;
 import no.hasmac.jsonld.lang.Keywords;
@@ -36,8 +37,8 @@ public final class NodeMap {
     private final BlankNodeIdGenerator generator = new BlankNodeIdGenerator();
 
     public NodeMap() {
-        this.index = new LinkedHashMap<>();
-        this.index.put(Keywords.DEFAULT, new LinkedHashMap<>());
+        this.index = new Object2ObjectLinkedOpenHashMap<>(2);
+        this.index.put(Keywords.DEFAULT, new Object2ObjectLinkedOpenHashMap<>(1));
     }
 
     public void set(String graphName, String subject, String property, JsonValue value) {
@@ -47,8 +48,8 @@ public final class NodeMap {
         }
 
         index
-                .computeIfAbsent(graphName, x -> new LinkedHashMap<>())
-                .computeIfAbsent(subject, x -> new LinkedHashMap<>())
+                .computeIfAbsent(graphName, x -> new Object2ObjectLinkedOpenHashMap<>())
+                .computeIfAbsent(subject, x -> new Object2ObjectLinkedOpenHashMap<>(1))
                 .put(property, value);
     }
 

--- a/src/main/java/no/hasmac/jsonld/flattening/NodeMap.java
+++ b/src/main/java/no/hasmac/jsonld/flattening/NodeMap.java
@@ -38,8 +38,8 @@ public final class NodeMap {
     private final BlankNodeIdGenerator generator = new BlankNodeIdGenerator();
 
     public NodeMap() {
-        this.index = new Object2ObjectArrayMap<>(2);
-        this.index.put(Keywords.DEFAULT, new Object2ObjectLinkedOpenHashMap<>(1));
+        this.index = new Object2ObjectArrayMap<>(1);
+        this.index.put(Keywords.DEFAULT, new LinkedHashMap<>());
     }
 
     public void set(String graphName, String subject, String property, JsonValue value) {
@@ -49,7 +49,7 @@ public final class NodeMap {
         }
 
         index
-                .computeIfAbsent(graphName, x -> new Object2ObjectLinkedOpenHashMap<>())
+                .computeIfAbsent(graphName, x -> new LinkedHashMap<>())
                 .computeIfAbsent(subject, x -> new Object2ObjectArrayMap<>(1))
                 .put(property, value);
     }

--- a/src/main/java/no/hasmac/jsonld/flattening/NodeMapBuilder.java
+++ b/src/main/java/no/hasmac/jsonld/flattening/NodeMapBuilder.java
@@ -15,6 +15,7 @@
  */
 package no.hasmac.jsonld.flattening;
 
+import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
 import no.hasmac.jsonld.JsonLdError;
 import no.hasmac.jsonld.JsonLdErrorCode;
@@ -129,7 +130,7 @@ public final class NodeMapBuilder {
         }
 
         // 2.
-        final Map<String, JsonValue> elementObject = new Object2ObjectLinkedOpenHashMap<>(element.asJsonObject());
+        final Map<String, JsonValue> elementObject = new Object2ObjectArrayMap<>(element.asJsonObject());
 
         // 3.
         if (elementObject.containsKey(Keywords.TYPE)) {

--- a/src/main/java/no/hasmac/jsonld/flattening/NodeMapBuilder.java
+++ b/src/main/java/no/hasmac/jsonld/flattening/NodeMapBuilder.java
@@ -15,6 +15,7 @@
  */
 package no.hasmac.jsonld.flattening;
 
+import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
 import no.hasmac.jsonld.JsonLdError;
 import no.hasmac.jsonld.JsonLdErrorCode;
 import no.hasmac.jsonld.ModifiableJsonArray;
@@ -33,7 +34,6 @@ import jakarta.json.JsonValue;
 import jakarta.json.JsonValue.ValueType;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -129,7 +129,7 @@ public final class NodeMapBuilder {
         }
 
         // 2.
-        final Map<String, JsonValue> elementObject = new LinkedHashMap<>(element.asJsonObject());
+        final Map<String, JsonValue> elementObject = new Object2ObjectLinkedOpenHashMap<>(element.asJsonObject());
 
         // 3.
         if (elementObject.containsKey(Keywords.TYPE)) {
@@ -175,7 +175,7 @@ public final class NodeMapBuilder {
         // 5.
         else if (elementObject.containsKey(Keywords.LIST)) {
             // 5.1.
-            Map<String, JsonValue> result = new LinkedHashMap<>();
+            Map<String, JsonValue> result = new Object2ObjectLinkedOpenHashMap<>();
             result.put(Keywords.LIST, JsonValue.EMPTY_JSON_ARRAY);
 
             // 5.2.
@@ -350,7 +350,7 @@ public final class NodeMapBuilder {
                 // 6.9.
                 if (elementObject.containsKey(Keywords.REVERSE)) {
                     // 6.9.1.
-                    Map<String, JsonValue> referenced = new LinkedHashMap<>();
+                    Map<String, JsonValue> referenced = new Object2ObjectLinkedOpenHashMap<>();
                     referenced.put(Keywords.ID, JsonProvider.instance().createValue(id));
 
                     // 6.9.2.

--- a/src/main/java/no/hasmac/jsonld/json/JsonMapBuilder.java
+++ b/src/main/java/no/hasmac/jsonld/json/JsonMapBuilder.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
 import no.hasmac.jsonld.lang.Keywords;
 
 import jakarta.json.JsonArray;
@@ -85,7 +86,7 @@ public final class JsonMapBuilder {
     }
 
     public static JsonMapBuilder create() {
-        return new JsonMapBuilder(new LinkedHashMap<>());
+        return new JsonMapBuilder(new Object2ObjectArrayMap<>());
     }
 
     public Optional<JsonValue> get(String key) {

--- a/src/main/java/no/hasmac/jsonld/json/JsonUtils.java
+++ b/src/main/java/no/hasmac/jsonld/json/JsonUtils.java
@@ -15,13 +15,13 @@
  */
 package no.hasmac.jsonld.json;
 
-import no.hasmac.jsonld.StringUtils;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
 import jakarta.json.JsonString;
 import jakarta.json.JsonValue;
 import jakarta.json.JsonValue.ValueType;
+import no.hasmac.jsonld.StringUtils;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -79,7 +79,7 @@ public final class JsonUtils {
     }
 
     public static boolean isNull(final JsonValue value) {
-        return value == null || ValueType.NULL.equals(value.getValueType());
+        return value == null || ValueType.NULL == value.getValueType();
     }
 
     public static boolean isNotNull(final JsonValue value) {
@@ -87,49 +87,49 @@ public final class JsonUtils {
     }
 
     public static boolean isString(JsonValue value) {
-        return value != null && ValueType.STRING.equals(value.getValueType());
+        return value != null && ValueType.STRING == value.getValueType();
     }
 
     public static boolean isNotString(JsonValue value) {
-        return value == null || !ValueType.STRING.equals(value.getValueType());
+        return value == null || ValueType.STRING != value.getValueType();
     }
 
     public static boolean isNotArray(JsonValue value) {
-        return value == null || !ValueType.ARRAY.equals(value.getValueType());
+        return value == null || ValueType.ARRAY != value.getValueType();
     }
 
     public static boolean isArray(JsonValue value) {
-        return value != null && ValueType.ARRAY.equals(value.getValueType());
+        return value != null && ValueType.ARRAY == value.getValueType();
     }
 
     public static boolean isObject(JsonValue value) {
-        return value != null && ValueType.OBJECT.equals(value.getValueType());
+        return value != null && ValueType.OBJECT == value.getValueType();
     }
 
     public static boolean isNotObject(JsonValue value) {
-        return value == null || !ValueType.OBJECT.equals(value.getValueType());
+        return value == null || ValueType.OBJECT != value.getValueType();
     }
 
     public static boolean isNumber(JsonValue value) {
-        return value != null && ValueType.NUMBER.equals(value.getValueType());
+        return value != null && ValueType.NUMBER == value.getValueType();
     }
 
     public static boolean isNotBoolean(JsonValue value) {
         return value == null
-                || (!ValueType.TRUE.equals(value.getValueType())
-                && !ValueType.FALSE.equals(value.getValueType()));
+                || ValueType.TRUE != value.getValueType()
+                && ValueType.FALSE != value.getValueType();
     }
 
     public static boolean isNotNumber(JsonValue value) {
-        return value == null || !ValueType.NUMBER.equals(value.getValueType());
+        return value == null || ValueType.NUMBER != value.getValueType();
     }
 
     public static boolean isTrue(JsonValue value) {
-        return value != null && ValueType.TRUE.equals(value.getValueType());
+        return value != null && ValueType.TRUE == value.getValueType();
     }
 
     public static boolean isFalse(JsonValue value) {
-        return value != null && ValueType.FALSE.equals(value.getValueType());
+        return value != null && ValueType.FALSE == value.getValueType();
     }
 
     public static boolean isEmptyObject(JsonValue value) {
@@ -143,15 +143,15 @@ public final class JsonUtils {
     public static JsonObject toJsonObject(Map<String, JsonValue> map) {
         final JsonObjectBuilder builder = JsonProvider.instance().createObjectBuilder();
 
-        map.entrySet().forEach(e -> builder.add(e.getKey(), e.getValue()));
+        map.forEach(builder::add);
 
         return builder.build();
     }
 
     public static JsonObject merge(JsonObject target, JsonObject source) {
-        Map<String, JsonValue> targetMap = (new LinkedHashMap<>(target));
+        Map<String, JsonValue> targetMap = new LinkedHashMap<>(target);
 
-        source.forEach(targetMap::put);
+        targetMap.putAll(source);
 
         return toJsonObject(targetMap);
     }
@@ -162,7 +162,7 @@ public final class JsonUtils {
             return Collections.emptyList();
         }
 
-        if (JsonValue.ValueType.ARRAY.equals(value.getValueType())) {
+        if (JsonValue.ValueType.ARRAY == value.getValueType()) {
             return value.asJsonArray();
         }
 
@@ -175,7 +175,7 @@ public final class JsonUtils {
             return Stream.empty();
         }
 
-        if (JsonValue.ValueType.ARRAY.equals(value.getValueType())) {
+        if (JsonValue.ValueType.ARRAY == value.getValueType()) {
             return value.asJsonArray().stream();
         }
 
@@ -232,7 +232,7 @@ public final class JsonUtils {
     }
 
     public static void withStrings(JsonValue value, Consumer<String> addContainerMapping) {
-        if (JsonValue.ValueType.ARRAY.equals(value.getValueType())) {
+        if (JsonValue.ValueType.ARRAY == value.getValueType()) {
 
             JsonArray asJsonArray = value.asJsonArray();
             for (int i = 0, asJsonArraySize = asJsonArray.size(); i < asJsonArraySize; i++) {
@@ -248,7 +248,7 @@ public final class JsonUtils {
     }
 
     public static List<String> optimizedGetStrings(JsonValue value) {
-        if (JsonValue.ValueType.ARRAY.equals(value.getValueType())) {
+        if (JsonValue.ValueType.ARRAY == value.getValueType()) {
             JsonArray jsonArray = value.asJsonArray();
             if (jsonArray.isEmpty()) {
                 return List.of();

--- a/src/main/java/no/hasmac/rdf/impl/RdfGraphImpl.java
+++ b/src/main/java/no/hasmac/rdf/impl/RdfGraphImpl.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Set;
 
 import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import no.hasmac.rdf.RdfGraph;
 import no.hasmac.rdf.RdfResource;
 import no.hasmac.rdf.RdfTriple;
@@ -47,7 +48,7 @@ final class RdfGraphImpl implements RdfGraph {
 
         index
             .computeIfAbsent(triple.getSubject(), x -> new Object2ObjectArrayMap<>(1))
-            .computeIfAbsent(triple.getPredicate(), x -> new HashSet<>(1))
+            .computeIfAbsent(triple.getPredicate(), x -> new ObjectOpenHashSet<>(1))
             .add(triple.getObject());
 
         triples.add(triple);

--- a/src/main/java/no/hasmac/rdf/impl/RdfGraphImpl.java
+++ b/src/main/java/no/hasmac/rdf/impl/RdfGraphImpl.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
 import no.hasmac.rdf.RdfGraph;
 import no.hasmac.rdf.RdfResource;
 import no.hasmac.rdf.RdfTriple;
@@ -45,7 +46,7 @@ final class RdfGraphImpl implements RdfGraph {
         }
 
         index
-            .computeIfAbsent(triple.getSubject(), x -> new HashMap<>(1))
+            .computeIfAbsent(triple.getSubject(), x -> new Object2ObjectArrayMap<>(1))
             .computeIfAbsent(triple.getPredicate(), x -> new HashSet<>(1))
             .add(triple.getObject());
 


### PR DESCRIPTION
### After
```
Benchmark                                                            Mode  Cnt     Score     Error  Units
BasicProcessingAlgorithmsBenchmark.compactDatagovbeDcat              avgt    5  2827.898 ± 122.089  ms/op
BasicProcessingAlgorithmsBenchmark.compactDatagovbeDcatEmptyContext  avgt    5  1646.228 ±  21.398  ms/op
BasicProcessingAlgorithmsBenchmark.expandDatagovbeDcatFromCompact    avgt    5   608.064 ±  37.503  ms/op
BasicProcessingAlgorithmsBenchmark.expandDatagovbeDcatFromFlatten    avgt    5   608.795 ±  34.029  ms/op
BasicProcessingAlgorithmsBenchmark.flattenDatagovbeDcat              avgt    5  1062.812 ±  61.041  ms/op
BasicProcessingAlgorithmsBenchmark.flattenDatagovbeDcatFromCompact   avgt    5  6703.740 ± 329.593  ms/op
ToRdfLargeFilesBenchmark.datagovbeDcat                               avgt    5  1449.796 ± 116.118  ms/op
ToRdfSmallFilesBenchmark.csiro                                       avgt    5     0.123 ±   0.003  ms/op
ToRdfSmallFilesBenchmark.difiDataset                                 avgt    5     1.413 ±   0.008  ms/op
ToRdfSmallFilesBenchmark.geonorge                                    avgt    5     0.013 ±   0.001  ms/op
ToRdfSmallFilesBenchmark.schemaExample1                              avgt    5     1.038 ±   0.020  ms/op
ToRdfSmallFilesBenchmark.schemaExample2                              avgt    5     1.029 ±   0.002  ms/op
ToRdfSmallFilesBenchmark.schemaExample3                              avgt    5     1.075 ±   0.027  ms/op
ToRdfSmallFilesBenchmark.schemaExample4                              avgt    5     1.089 ±   0.111  ms/op
ToRdfSmallFilesBenchmark.schemaExtBib                                avgt    5     1.293 ±   0.012  ms/op
ToRdfSmallFilesBenchmark.schemaExtHealthLifeSci                      avgt    5     3.417 ±   0.003  ms/op
ToRdfSmallFilesBenchmark.schemaExtMeta                               avgt    5     1.104 ±   0.003  ms/op
```

```
# Benchmark: no.hasmac.jsonld.benchmark.OOMBenchmark.datagovbeDcatToRdf

# Run progress: 0.59% complete, ETA 1 days, 09:03:14
# Fork: 1 of 1
Iteration   1: 2159.635 ms/op
Iteration   2: 1143.654 ms/op
Iteration   3: 1078.584 ms/op
Iteration   4: 1073.792 ms/op
Iteration   5: 1063.986 ms/op
Iteration   6: 1028.278 ms/op
Iteration   7: 1038.740 ms/op
Iteration   8: 988.944 ms/op
Iteration   9: Terminating due to java.lang.OutOfMemoryError: Java heap space
```

ToRdfLargeFilesBenchmark.datagovbeDcat is considerably improved by this PR, but it seems to slow down some of the other benchmarks. We are using less memory though, since the OOM Benchmark manages an 8th iteration.