### PR TITLE
Fix native type term selection during JSON-LD compaction

### DIFF
--- a/src/main/java/no/hasmac/jsonld/compaction/UriCompaction.java
+++ b/src/main/java/no/hasmac/jsonld/compaction/UriCompaction.java
@@ -452,6 +452,22 @@ public final class UriCompaction {
             containers.add(Keywords.SET);
         }
 
+        if (Keywords.LANGUAGE.equals(typeLanguage)
+                && Keywords.NULL.equals(typeLanguageValue)
+                && JsonUtils.containsKey(value, Keywords.VALUE)
+                && JsonUtils.isObject(value)
+                && JsonUtils.isNotString(value.asJsonObject().get(Keywords.VALUE))
+                && !value.asJsonObject().containsKey(Keywords.TYPE)
+                && !value.asJsonObject().containsKey(Keywords.LANGUAGE)) {
+
+            final String inferredType = inferTypeForNativeValue(variable);
+
+            if (inferredType != null) {
+                typeLanguage = Keywords.TYPE;
+                typeLanguageValue = inferredType;
+            }
+        }
+
         // 4.10.
         containers.add(Keywords.NONE);
 
@@ -555,5 +571,43 @@ public final class UriCompaction {
         // 4.20.
         String term = activeContext.termSelector(variable, containers, typeLanguage).match(preferredValues);
         return term;
+    }
+
+    private String inferTypeForNativeValue(final String variable) {
+
+        String inferredType = null;
+
+        for (Entry<String, TermDefinition> termEntry : activeContext.getTermsMapping().entrySet()) {
+
+            final TermDefinition termDefinition = termEntry.getValue();
+
+            if (termDefinition == null) {
+                continue;
+            }
+
+            final String uriMapping = termDefinition.getUriMapping();
+
+            if (uriMapping == null || !uriMapping.equals(variable)) {
+                continue;
+            }
+
+            final String typeMapping = termDefinition.getTypeMapping();
+
+            if (typeMapping == null
+                    || Keywords.ID.equals(typeMapping)
+                    || Keywords.VOCAB.equals(typeMapping)
+                    || Keywords.NONE.equals(typeMapping)
+                    || Keywords.JSON.equals(typeMapping)) {
+                continue;
+            }
+
+            if (inferredType == null) {
+                inferredType = typeMapping;
+            } else if (!inferredType.equals(typeMapping)) {
+                return null;
+            }
+        }
+
+        return inferredType;
     }
 }

--- a/src/test/java/no/hasmac/jsonld/compaction/UriCompactionNativeTypesTest.java
+++ b/src/test/java/no/hasmac/jsonld/compaction/UriCompactionNativeTypesTest.java
@@ -1,0 +1,42 @@
+package no.hasmac.jsonld.compaction;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import no.hasmac.jsonld.JsonLdError;
+import no.hasmac.jsonld.JsonLdOptions;
+import no.hasmac.jsonld.context.ActiveContext;
+import no.hasmac.jsonld.json.JsonProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class UriCompactionNativeTypesTest {
+
+    @Test
+    void selectsTermForNativeNumberWithTypeMapping() throws JsonLdError {
+        JsonObject context = Json.createObjectBuilder()
+                .add("xsd", "http://www.w3.org/2001/XMLSchema#")
+                .add("ex", "http://example.org/")
+                .add("@vocab", "http://example.org/")
+                .add("alert_id", Json.createObjectBuilder().add("@id", "alert_id"))
+                .add("x", Json.createObjectBuilder().add("@id", "x").add("@type", "xsd:float"))
+                .add("y", Json.createObjectBuilder().add("@id", "y").add("@type", "xsd:float"))
+                .add("z", Json.createObjectBuilder().add("@id", "z").add("@type", "xsd:float"))
+                .build();
+
+        ActiveContext activeContext = new ActiveContext(null, null, new JsonLdOptions())
+                .newContext()
+                .create(context, null);
+
+        JsonObject value = Json.createObjectBuilder()
+                .add("@value", JsonProvider.instance().createValue(18476.0))
+                .build();
+
+        String compacted = activeContext.uriCompaction()
+                .value(value)
+                .vocab(true)
+                .compact("http://example.org/z");
+
+        assertEquals("z", compacted);
+    }
+}


### PR DESCRIPTION
## Summary
- infer typed term mappings when compaction sees native numeric values so framed output keeps the expected keys
- add a unit test reproducing the JSON-LD framing regression reported in eclipse-rdf4j/rdf4j#5521

## Testing
- mvn -Dtest=UriCompactionNativeTypesTest test

------
https://chatgpt.com/codex/tasks/task_e_68eab7e312a8832e91657b62c14069bd